### PR TITLE
Allow audience creation without CSV file upload

### DIFF
--- a/client/src/pages/Audience/CreateAudience.js
+++ b/client/src/pages/Audience/CreateAudience.js
@@ -26,18 +26,20 @@ const CreateAudience = () => {
         // Reset validation errors
         setValidationError({ name: false, file: false });
 
-        // Validate input fields
-        if (!audienceName || !file) {
+        // Validate input fields - only audience name is required
+        if (!audienceName) {
             setValidationError({
                 name: !audienceName,
-                file: !file,
+                file: false,
             });
             return;
         }
 
         const formData = new FormData();
         formData.append('name', audienceName);
-        formData.append('file', file);
+        if (file) {
+            formData.append('file', file);
+        }
 
         // Call the createAudience function from the hook
         const response = await createAudience(formData);
@@ -67,7 +69,7 @@ const CreateAudience = () => {
                                 Create a New Audience
                             </Typography>
                             <Typography sx={{ fontSize: 13 }} color="text.secondary">
-                                Define your audience and upload a CSV file with their contact information.
+                                Define your audience and optionally upload a CSV file with their contact information.
                             </Typography>
                         </Grid>
                     </Grid>
@@ -98,8 +100,9 @@ const CreateAudience = () => {
                             {/* Instructions */}
                             <Grid item xs={12}>
                                 <Typography variant="body1" sx={{ mb: 1 }}>
-                                    Please upload a CSV file with the required fields: <strong>First Name</strong> and <strong>Email</strong>.
+                                    Optionally upload a CSV file with the required fields: <strong>First Name</strong> and <strong>Email</strong>.
                                     If no first name is available, use generic values like <strong>"user"</strong> or <strong>"employee"</strong>.
+                                    You can also create an empty audience and add contacts manually later.
                                 </Typography>
                                 <Typography variant="body1" sx={{ mb: 2 }}>
                                     <Link href="/sample-contacts.csv" sx={{ color: '#00bfff' }}>Download a sample CSV file</Link> to see the expected format.
@@ -113,16 +116,7 @@ const CreateAudience = () => {
                                     type="file"
                                     onChange={handleFileChange}
                                     inputProps={{ accept: '.csv' }}
-                                    error={validationError.file} // Set error state if file is missing
-                                    helperText={validationError.file ? "CSV file is required" : "Upload a CSV file with your audience's contacts."}
-                                    required
-                                    sx={{
-                                        '& .MuiInputLabel-root': {
-                                            '& .MuiInputLabel-asterisk': {
-                                                color: 'error.main',
-                                            },
-                                        },
-                                    }}
+                                    helperText="Upload a CSV file with your audience's contacts (optional)."
                                 />
                             </Grid>
 
@@ -143,7 +137,7 @@ const CreateAudience = () => {
                 <DialogTitle>Success</DialogTitle>
                 <DialogContent>
                     <DialogContentText>
-                        An audience containing your uploaded contacts has been successfully created!
+                        Your audience has been successfully created!
                         You can now view the details of the audience by navigating to the audience details page.
                     </DialogContentText>
                 </DialogContent>

--- a/controllers/audienceController.js
+++ b/controllers/audienceController.js
@@ -95,10 +95,8 @@ export const createAudience = async (req, res) => {
                 });
             }
         } else {
-            return res.status(400).json({
-                success: false,
-                message: 'No file was uploaded. Please upload a valid CSV file.'
-            });
+            // Allow creating audience without CSV file - contacts will be empty
+            contactIds = [];
         }
 
         // Create the new audience with the contacts

--- a/models/Audience.js
+++ b/models/Audience.js
@@ -13,8 +13,7 @@ const audienceSchema = new Schema({
     },
     contacts: [{
         type: Schema.Types.ObjectId,
-        ref: 'Contact',
-        required: true
+        ref: 'Contact'
     }],
 }, { timestamps: true });
 


### PR DESCRIPTION
## Changes Made

### Backend Changes
- **Fixed Audience Model**: Removed `required: true` from contacts array to allow empty audiences
- **Updated Controller**: Modified `createAudience` to support creation without CSV file upload
- **Backward Compatible**: Existing functionality with CSV uploads continues to work

### Frontend Changes
- **Removed file validation**: CSV file upload is now optional
- **Updated form submission**: Only appends file to FormData if it exists
- **Updated UI messaging**: Changed instructions to indicate file upload is optional
- **Removed required styling**: File upload field no longer shows as required
- **Updated success message**: Made it generic to work with or without contacts

## Benefits
- Users can create audiences with just a name
- Optionally upload CSV file for bulk contact import
- Add contacts manually later via audience detail page
- Clear UI messaging about optional file upload
- Proper validation (only audience name is required)
- Backward compatible with existing CSV upload functionality

## Testing
- [x] Create audience with just name (no file)
- [x] Create audience with name + CSV file
- [x] Verify empty audience can be viewed and managed
- [x] Confirm existing CSV upload functionality still works
- [x] Test manual contact addition to empty audience

## Files Changed
- `models/Audience.js` - Removed required constraint from contacts
- `controllers/audienceController.js` - Allow creation without file
- `client/src/pages/Audience/CreateAudience.js` - Updated UI and validation