### PR TITLE
fix: update health check endpoint in startup pipeline

### DIFF
--- a/.github/workflows/startup-health.yml
+++ b/.github/workflows/startup-health.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Install wait-on
         run: npm install -g wait-on@8.0.3
 
-      - name: Wait for backend /health route
-        run: wait-on http://localhost:8080/health --timeout=30000
+      - name: Wait for backend /api/system/health route
+        run: wait-on http://localhost:8080/api/system/health --timeout=30000
 
   test-frontend:
     name: Frontend Build Check


### PR DESCRIPTION
## Summary
Fixes the failing "Startup & Build Check" pipeline by updating the health check endpoint URL to match the actual API route structure.

## Problem
The GitHub Actions workflow was trying to access `http://localhost:8080/health`, but the health check endpoint is actually available at `http://localhost:8080/api/system/health`. This caused the pipeline to fail during the backend startup check phase.

## Solution
Updated the workflow file `.github/workflows/startup-health.yml` to use the correct health check endpoint:
- Changed from: `http://localhost:8080/health`
- Changed to: `http://localhost:8080/api/system/health`

## Changes Made
- Updated the `wait-on` command in the backend startup check step to use the correct API endpoint
- Updated the step name to reflect the correct endpoint being tested