### PR TITLE
fix: correct initRootAdmin.js path in docker entrypoint script

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "Initializing root admin (if needed)..."
-node initRootAdmin.js
+node scripts/initRootAdmin.js
 
 echo "Starting main application..."
 exec node app.js 


### PR DESCRIPTION
The `docker-entrypoint.sh` script was trying to execute `initRootAdmin.js` from the root directory, but the file is actually located in the `scripts/` directory.

### Solution
Updated `docker-entrypoint.sh` to use the correct path:
- **Before:** `node initRootAdmin.js`
- **After:** `node scripts/initRootAdmin.js`