### PR TITLE
fix: ensure expired session 401 on change-password triggers logout

### DIFF
--- a/client/src/services/axiosInstance.js
+++ b/client/src/services/axiosInstance.js
@@ -22,10 +22,9 @@ axiosInstance.interceptors.request.use(
     }
 );
 
-// Paths that may return 401 for business logic (e.g. wrong password), not session invalid. Do not logout/redirect on 401 for these.
+// Paths that may return 401 for business logic (e.g. wrong credentials), not session invalid. Do not logout/redirect on 401 for these.
 const EXEMPT_401_LOGOUT_PATHS = [
     '/api/auth',
-    '/api/users/me/change-password',
 ];
 
 axiosInstance.interceptors.response.use(

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -57,7 +57,7 @@ export async function changePassword(req, res) {
     if (!user) return res.status(404).json({ success: false, error: 'User not found' });
     const valid = await user.comparePassword(currentPassword);
     if (!valid) {
-      return res.status(401).json({ success: false, error: 'Current password is incorrect' });
+      return res.status(400).json({ success: false, error: 'Current password is incorrect' });
     }
     user.password = newPassword;
     await user.save();


### PR DESCRIPTION
## Summary
Stops exempting the change-password endpoint from the global 401 logout flow so that expired or invalid sessions on this route trigger logout and redirect to login instead of keeping stale credentials.

## Problem
- Paths in `EXEMPT_401_LOGOUT_PATHS` skip the 401 → clear token + redirect behavior.
- `/api/users/me/change-password` was exempted to avoid logging users out when they enter a **wrong current password** (controller returned 401).
- That exemption applied to **all** 401s on the path, including 401s from `authMiddleware` for expired/invalid tokens.
- Result: expired sessions on the change-password page did not logout or redirect; the app kept stale credentials.

## Solution
1. **Backend** (`controllers/userController.js`): Return **400** instead of **401** for "Current password is incorrect". The user is already authenticated; wrong current password is a validation error, not an auth failure.
2. **Frontend** (`client/src/services/axiosInstance.js`): Remove `/api/users/me/change-password` from `EXEMPT_401_LOGOUT_PATHS`. The only 401 on this route is now from `authMiddleware` (expired/invalid token), which correctly triggers logout.

## Testing
- Wrong current password → 400, error message shown in Security tab; no logout.
- Expired/invalid token on change-password request → 401, token cleared and redirect to `/console`.